### PR TITLE
Use full path when loading/saving workspaces

### DIFF
--- a/R/saitem.R
+++ b/R/saitem.R
@@ -8,10 +8,10 @@ NULL
 #'
 #' @param jsa Java SAItem object.
 #' @param items vector of characters containing the variables to extract.
-#' See [rjd3x13::userdefined_variables_x13()] or [rjd3tramoseats::userdefined_variables_tramoseats()]. By default, extracts all the possible variables.
+#' See [rjd3x13::x13_dictionary()] or [rjd3tramoseats::tramoseats_dictionary()]. By default, extracts all the possible variables.
 #'
 #' @details A SAItem contains more information than just the results of a model.
-#' All those informations are extracted with the `jsa.read()` function that returns a list with 5 objects:
+#' All those informations are extracted with the `.jsa_read()` function that returns a list with 5 objects:
 #'
 #' - `ts`: the raw time series.
 #' - `domainSpec`: initial specification. Reference for any relaxing of some elements of the specification.

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -166,9 +166,15 @@ load_workspace<-function(file){
 save_workspace <- function(jws, file, replace = FALSE) {
   # version <- match.arg(tolower(version)[1], c("jd3", "jd2"))
   version <- "jd3"
-  .jcall(jws, "Z", "saveAs", file, version, !replace)
+  invisible(.jcall(jws, "Z", "saveAs", full_path(file), version, !replace))
 }
 
+full_path <- function(path) {
+  base::file.path(
+    base::normalizePath(dirname(path), mustWork = TRUE, winslash = "/"),
+    base::basename(path),
+    fsep = "/")
+}
 
 
 #' Add Calendar to Workspace

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -101,8 +101,8 @@ get_context<-function(jws){
   }
   if (!file.exists(file) | length(grep("\\.xml$",file)) == 0)
     stop("The file doesn't exist or isn't a .xml file !")
-
-  jws<-.jcall("jdplus/sa/base/workspace/Ws", "Ljdplus/sa/base/workspace/Ws;", "open", file)
+  full_file_name <- full_path(file)
+  jws<-.jcall("jdplus/sa/base/workspace/Ws", "Ljdplus/sa/base/workspace/Ws;", "open", full_file_name)
   return (jws)
 }
 

--- a/man/dot-jsa_read.Rd
+++ b/man/dot-jsa_read.Rd
@@ -13,7 +13,7 @@
 \item{jsa}{Java SAItem object.}
 
 \item{items}{vector of characters containing the variables to extract.
-See \code{\link[rjd3x13:userdefined_variables_x13]{rjd3x13::userdefined_variables_x13()}} or \code{\link[rjd3tramoseats:userdefined_variables_tramoseats]{rjd3tramoseats::userdefined_variables_tramoseats()}}. By default, extracts all the possible variables.}
+See \code{\link[rjd3x13:x13_dictionary]{rjd3x13::x13_dictionary()}} or \code{\link[rjd3tramoseats:tramoseats_dictionary]{rjd3tramoseats::tramoseats_dictionary()}}. By default, extracts all the possible variables.}
 }
 \description{
 \code{.jsa_results()} extracts specific variables of the model of the SAItem while
@@ -21,7 +21,7 @@ See \code{\link[rjd3x13:userdefined_variables_x13]{rjd3x13::userdefined_variable
 }
 \details{
 A SAItem contains more information than just the results of a model.
-All those informations are extracted with the \code{jsa.read()} function that returns a list with 5 objects:
+All those informations are extracted with the \code{.jsa_read()} function that returns a list with 5 objects:
 \itemize{
 \item \code{ts}: the raw time series.
 \item \code{domainSpec}: initial specification. Reference for any relaxing of some elements of the specification.


### PR DESCRIPTION
- full path is now used loading/saving workspaces to avoid some problems with relative path (for example executing a code in rmarkdown file)
- some documentation update