### PR TITLE
fix #105

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* `save_workspace` generates a warning when a workspace already exists and `replace = FALSE` (the default)  [#105](https://github.com/rjdverse/rjd3workspace/issues/105)
+
 ## [3.8.0] - 2026-07-17
 
 ### Fixed

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -531,12 +531,15 @@ jread_workspace <- function(jws, compute = TRUE) {
 #' @title Save Workspace
 #'
 #' @description
-#' Function allowing to write a workspace as a collection of xml files readable by JDemetra+ Graphical
-#' User Interface.
+#' Function allowing to write a workspace as a collection of xml files readable
+#' by JDemetra+ Graphical User Interface.
 #'
 #' @param jws Workspace object to export.
 #' @param file path where to export the 'JDemetra+' Workspace (.xml file).
-#' @param replace boolean indicating if the Workspace should be replaced if it already exists.
+#' @param replace boolean indicating if the Workspace should be replaced if it
+#'   already exists.
+#' @param verbose Boolean indicating whether to print additional information.
+#'   Default is `TRUE`.
 #'
 #' @returns A boolean indicating if the saving was successful.
 #'
@@ -552,17 +555,36 @@ jread_workspace <- function(jws, compute = TRUE) {
 #' }
 #'
 #' @export
-save_workspace <- function(jws, file, replace = FALSE) {
+save_workspace <- function(jws, file, replace = FALSE, verbose = TRUE) {
     # version <- match.arg(tolower(version)[1], c("jd3", "jd2"))
     version <- "jd3"
     file <- full_path(file)
-    if (replace && file.exists(file)) {
+
+    if (!replace && file.exists(file)) {
+        if (verbose) {
+            warning(
+                "A workspace already exists. ",
+                "To overwrite it, use the argument `replace = TRUE`.",
+                call. = FALSE
+            )
+        }
+        return(FALSE)
+    }
+
+    if (verbose) {
+        message("The workspace will be written to ", file, ".")
+    }
+    if (file.exists(file)) {
         base::file.remove(file)
         base::unlink(
             gsub("\\.xml$", "", file),
             recursive = TRUE
         )
+        if (verbose) {
+            message("A workspace already exists and will be overwritten.")
+        }
     }
+
     invisible(.jcall(jws, "Z", "saveAs", file, version, !replace))
 }
 

--- a/man/save_workspace.Rd
+++ b/man/save_workspace.Rd
@@ -4,21 +4,25 @@
 \alias{save_workspace}
 \title{Save Workspace}
 \usage{
-save_workspace(jws, file, replace = FALSE)
+save_workspace(jws, file, replace = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{jws}{Workspace object to export.}
 
 \item{file}{path where to export the 'JDemetra+' Workspace (.xml file).}
 
-\item{replace}{boolean indicating if the Workspace should be replaced if it already exists.}
+\item{replace}{boolean indicating if the Workspace should be replaced if it
+already exists.}
+
+\item{verbose}{Boolean indicating whether to print additional information.
+Default is \code{TRUE}.}
 }
 \value{
 A boolean indicating if the saving was successful.
 }
 \description{
-Function allowing to write a workspace as a collection of xml files readable by JDemetra+ Graphical
-User Interface.
+Function allowing to write a workspace as a collection of xml files readable
+by JDemetra+ Graphical User Interface.
 }
 \examples{
 \dontshow{if (rjd3jars::check_java_version(silent = TRUE)) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/test-workspace.R
+++ b/tests/testthat/test-workspace.R
@@ -1,0 +1,41 @@
+test_that("save_workspace works", {
+    path_ws <- tempfile(fileext = ".xml")
+
+    jws <- jws_new()
+    jsap1 <- jws_sap_new(jws, "sap1")
+    add_sa_item(jsap1, name = "serie_1", x = rjd3toolkit::ABS$X0.2.09.10.M, rjd3x13::x13_spec())
+
+    expect_message(save_workspace(jws, path_ws))
+
+    jws2 <- jws_open(path_ws)
+    jsap2 <- jws_sap(jws, idx = 1L)
+    expect_identical(sap_sai_count(jsap2), 1L)
+    expect_identical(sap_name(jsap2), "sap1")
+    expect_identical(sap_sai_names(jsap2), "serie_1")
+
+    jws <- jws_new()
+    jsap1 <- jws_sap_new(jws, "sap1")
+    add_sa_item(jsap1, name = "serie_1", x = rjd3toolkit::ABS$X0.2.09.10.M, rjd3x13::x13_spec())
+
+    expect_warning(save_workspace(jws, path_ws, replace = FALSE))
+    expect_no_warning(save_workspace(jws, path_ws, replace = FALSE, verbose = FALSE))
+
+    jws2 <- jws_open(path_ws)
+    jsap2 <- jws_sap(jws, idx = 1L)
+    expect_identical(sap_sai_count(jsap2), 1L)
+    expect_identical(sap_name(jsap2), "sap1")
+    expect_identical(sap_sai_names(jsap2), "serie_1")
+
+    jws <- jws_new()
+    jsap1 <- jws_sap_new(jws, "sap1")
+    add_sa_item(jsap1, name = "serie_2", x = rjd3toolkit::ABS$X0.2.09.10.M, rjd3x13::x13_spec())
+
+    expect_message(expect_message(save_workspace(jws, path_ws, replace = TRUE)))
+    expect_no_message(save_workspace(jws, path_ws, replace = TRUE, verbose = FALSE))
+
+    jws2 <- jws_open(path_ws)
+    jsap2 <- jws_sap(jws, idx = 1L)
+    expect_identical(sap_sai_count(jsap2), 1L)
+    expect_identical(sap_name(jsap2), "sap1")
+    expect_identical(sap_sai_names(jsap2), "serie_2")
+})


### PR DESCRIPTION
fix #105 
`save_workspace` has now a `verbose` argument to display message and warning.