### PR TITLE
add verbose and documentation to fix #101 and fix #92

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+* New `verbose` argument in `write_calendars` and document behavious when the list of calendars is not named [#92](https://github.com/rjdverse/rjd3workspace/issues/92)
+* New message in `write_calendars` when the single calendar is not named (and renamed in `"cal"`) [#101](https://github.com/rjdverse/rjd3workspace/issues/101)
+
 ## [3.8.0] - 2026-07-17
 
 ### Fixed

--- a/R/utils.R
+++ b/R/utils.R
@@ -305,17 +305,26 @@ read_calendars <- function(file) {
     return(rjd3toolkit::.jd2r_calendars(jspec))
 }
 
-#' Write a Calendar file
+#' @title Write a Calendar file
 #'
 #' @description
 #' The calendar file is a xml file like the one JDemetra+ would write when
 #' defining a calendar in the Graphical User Interface.
 #' Calendars can be defined with `rjd3toolkit::national_calendar`
 #'
-#' @param calendars list of calendars or a `JD3_CALENDAR` object
+#' @param calendars named list of calendars or a `JD3_CALENDAR` object
 #' @param file xml format
+#' @param verbose Boolean indicating whether to print additional information.
+#'   Default is `TRUE`.
 #'
 #' @returns \code{NULL} returned invisibly
+#'
+#' @details
+#' If `calendars` is a single calendar (`JD3_CALENDAR` object), it will be
+#' named `cal` by default.
+#' If `calendars` is a list of calendars (`JD3_CALENDAR` object). Then they all
+#' must be named. Else, a error is risen.
+#'
 #' @examplesIf rjd3jars::check_java_version(silent = TRUE)
 #' library("rjd3toolkit")
 #' BE <- national_calendar(list(
@@ -336,8 +345,11 @@ read_calendars <- function(file) {
 #' write_calendars(BE, file = calendar_path)
 #' write_calendars(list(BEL_cal = BE), file = calendar_path)
 #' @export
-write_calendars <- function(calendars, file) {
+write_calendars <- function(calendars, file, verbose = TRUE) {
     if (inherits(calendars, "JD3_CALENDAR")) {
+        if (verbose) {
+            message("The calendar will be renamed `cal`.")
+        }
         calendars <- list(cal = calendars)
     } else if (
         !(is.list(calendars) &&
@@ -357,6 +369,7 @@ write_calendars <- function(calendars, file) {
         jcal,
         as.character(file)
     )
+    return(invisible(NULL))
 }
 
 #' @title Read auxiliary regressors file

--- a/man/write_calendars.Rd
+++ b/man/write_calendars.Rd
@@ -4,12 +4,15 @@
 \alias{write_calendars}
 \title{Write a Calendar file}
 \usage{
-write_calendars(calendars, file)
+write_calendars(calendars, file, verbose = TRUE)
 }
 \arguments{
-\item{calendars}{list of calendars or a \code{JD3_CALENDAR} object}
+\item{calendars}{named list of calendars or a \code{JD3_CALENDAR} object}
 
 \item{file}{xml format}
+
+\item{verbose}{Boolean indicating whether to print additional information.
+Default is \code{TRUE}.}
 }
 \value{
 \code{NULL} returned invisibly
@@ -18,6 +21,12 @@ write_calendars(calendars, file)
 The calendar file is a xml file like the one JDemetra+ would write when
 defining a calendar in the Graphical User Interface.
 Calendars can be defined with \code{rjd3toolkit::national_calendar}
+}
+\details{
+If \code{calendars} is a single calendar (\code{JD3_CALENDAR} object), it will be
+named \code{cal} by default.
+If \code{calendars} is a list of calendars (\code{JD3_CALENDAR} object). Then they all
+must be named. Else, a error is risen.
 }
 \examples{
 \dontshow{if (rjd3jars::check_java_version(silent = TRUE)) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,24 @@
+test_that("write_calendars works", {
+    BE <- rjd3toolkit::national_calendar(list(
+        rjd3toolkit::fixed_day(7, 21),
+        rjd3toolkit::special_day("NEWYEAR"),
+        rjd3toolkit::special_day("CHRISTMAS"),
+        rjd3toolkit::special_day("MAYDAY"),
+        rjd3toolkit::special_day("EASTERMONDAY"),
+        rjd3toolkit::special_day("ASCENSION"),
+        rjd3toolkit::special_day("WHITMONDAY"),
+        rjd3toolkit::special_day("ASSUMPTION"),
+        rjd3toolkit::special_day("ALLSAINTSDAY"),
+        rjd3toolkit::special_day("ARMISTICE")
+    ))
+
+    calendar_path <- tempfile(pattern = "calendar", fileext = ".xml")
+
+    expect_message(write_calendars(BE, file = calendar_path))
+    expect_no_message(write_calendars(BE, file = calendar_path, verbose = FALSE))
+    expect_no_message(write_calendars(list(BEL_cal = BE), file = calendar_path))
+    expect_error(write_calendars(list(BE), file = calendar_path))
+    expect_error(write_calendars(list(BE), file = calendar_path))
+    expect_error(write_calendars(list(BE, BE), file = calendar_path))
+    expect_error(write_calendars(list(BE, BE, my_cal = BE, BE), file = calendar_path))
+})


### PR DESCRIPTION
fix #101
fix #92

New message to warn that single calendars are renamed in `"cal"`